### PR TITLE
rename to use @knapsack-labs npm scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@knapsack/figma-api",
+  "name": "@knapsack-labs/figma-api",
   "version": "1.12.0",
   "description": "Figma js typed api",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "type": "git",
     "url": "https://github.com/knapsack-cloud/figma-api"
   },
-  "author": "KnapsackBot <53622700+KnapsackBot@users.noreply.github.com>"
+  "author": "KnapsackBot <53622700+KnapsackBot@users.noreply.github.com>",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Promises & ES6.
 
 ## Install
 
-`npm i figma-api`
+`npm i @knapsack-labs/figma-api`
 
 or browser version:
 
@@ -24,7 +24,7 @@ All api in browser exported to global `Figma` object.
 ## Usage
 
 ```ts
-import * as Figma from 'figma-api';
+import * as Figma from '@knapsack-labs/figma-api';
 
 export async function main() {
     const api = new Figma.Api({


### PR DESCRIPTION
## Release Notes

Now use this package name: `@knapsack-labs/figma-api`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.13.0--canary.3.0e3ed25.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-labs/figma-api@1.13.0--canary.3.0e3ed25.0
  # or 
  yarn add @knapsack-labs/figma-api@1.13.0--canary.3.0e3ed25.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
