### PR TITLE
refactor: add missing fields in `GetFileResult`

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -167,6 +167,9 @@ export interface GetFileResult {
   lastModified: string;
   thumbnailUrl: string;
   version: string;
+  role: string;
+  editorType: string;
+  linkAccess: string;
   document: Node<'DOCUMENT'>;
   components: { [nodeId: string]: Component };
   componentSets: {


### PR DESCRIPTION
`GetFileResult` type is outdated. Adding the missing fields: role, editorType and linkAccess.

source: https://www.figma.com/developers/api#get-files-endpoint
